### PR TITLE
Fix opiate drug screening

### DIFF
--- a/input/pagecontent/cql/OpioidCDSCommon.cql
+++ b/input/pagecontent/cql/OpioidCDSCommon.cql
@@ -34,6 +34,7 @@ valueset "Non-opioid drug urine screening": 'http://fhir.org/guides/cdc/opioid-c
 valueset "Naloxone medications": 'http://fhir.org/guides/cdc/opioid-cds/ValueSet/naloxone-medications'
 valueset "Opioid misuse assessment procedure": 'http://fhir.org/guides/cdc/opioid-cds/ValueSet/opioid-misuse-assessment-procedure'
 valueset "Opioid drug urine screening": 'http://fhir.org/guides/cdc/opioid-cds/ValueSet/opioid-drug-urine-screening'
+valueset "Opiate drug urine screening": 'http://fhir.org/guides/cdc/opioid-cds/ValueSet/opiate-specific-urine-drug-screening-tests'
 valueset "Hospice Disposition": 'http://fhir.org/guides/cdc/opioid-cds/ValueSet/hospice-disposition' // Harvested from VSAC - OID: 2.16.840.1.113762.1.4.1108.15
 valueset "Hospice Finding Codes": 'http://fhir.org/guides/cdc/opioid-cds/ValueSet/hospice-finding'
 valueset "Hospice Procedure Codes": 'http://fhir.org/guides/cdc/opioid-cds/ValueSet/hospice-procedure'

--- a/input/pagecontent/cql/OpioidCDSCommonConfig.cql
+++ b/input/pagecontent/cql/OpioidCDSCommonConfig.cql
@@ -53,7 +53,7 @@ define "PDMP Data Not Reviewed in Past 90 Days Criteria Enabled":
 
 // Recommendation 10
 define "Opiate Urine Screening Check Enabled":
-  false
+  true
 
 // Recommendation 12
 define "Evidence Based Treatment Criteria For Opioid Use Disorder":

--- a/input/pagecontent/cql/OpioidCDSREC10Common.cql
+++ b/input/pagecontent/cql/OpioidCDSREC10Common.cql
@@ -71,7 +71,7 @@ define "Patient had Urine Screening in Last 12 Months":
     or exists ("Cocaine Screenings")
     or exists ("PCP Screenings")
   )
-  and
+  or
     if Config."Opiate Urine Screening Check Enabled" then
       exists ("Opiate Screenings")
     else

--- a/input/pagecontent/cql/OpioidCDSREC10Common.cql
+++ b/input/pagecontent/cql/OpioidCDSREC10Common.cql
@@ -87,7 +87,7 @@ define "Non-opioid Screenings":
 
 define "Opiate Screenings":
   GetRelevantScreenings("Laboratory Observations" LabObservations
-    where (LabObservations.code in Common."Opioid drug urine screening")
+    where (LabObservations.code in Common."Opiate drug urine screening")
   )
 
 define "Cocaine Screenings":

--- a/input/pagecontent/requests/OpioidCDSREC10/request-example-rec-10-illicit-drugs-POS-Opiate-non-synthetic.json
+++ b/input/pagecontent/requests/OpioidCDSREC10/request-example-rec-10-illicit-drugs-POS-Opiate-non-synthetic.json
@@ -286,9 +286,9 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "version": "2.68",
-                    "code": "11246-6",
-                    "display": "oxyCODONE (U) [Mass/Vol]"
+                    "version": "2.72",
+                    "code": "19600-6",
+                    "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
                   }
                 ]
               },

--- a/input/pagecontent/requests/OpioidCDSREC10/request-example-rec-10-illicit-drugs-POS-Opiate.json
+++ b/input/pagecontent/requests/OpioidCDSREC10/request-example-rec-10-illicit-drugs-POS-Opiate.json
@@ -244,9 +244,9 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "version": "2.68",
-                    "code": "11246-6",
-                    "display": "oxyCODONE (U) [Mass/Vol]"
+                    "version": "2.72",
+                    "code": "19600-6",
+                    "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
                   }
                 ]
               },
@@ -306,9 +306,9 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "version": "2.68",
-                    "code": "11246-6",
-                    "display": "oxyCODONE (U) [Mass/Vol]"
+                    "version": "2.72",
+                    "code": "19600-6",
+                    "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
                   }
                 ]
               },
@@ -368,9 +368,9 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "version": "2.68",
-                    "code": "11246-6",
-                    "display": "oxyCODONE (U) [Mass/Vol]"
+                    "version": "2.72",
+                    "code": "19600-6",
+                    "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
                   }
                 ]
               },

--- a/input/pagecontent/requests/OpioidCDSREC10OrderSign/request-example-rec-10-order-sign-illicit-drugs-POS-Opiate.json
+++ b/input/pagecontent/requests/OpioidCDSREC10OrderSign/request-example-rec-10-order-sign-illicit-drugs-POS-Opiate.json
@@ -241,9 +241,9 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "version": "2.68",
-                    "code": "11246-6",
-                    "display": "oxyCODONE (U) [Mass/Vol]"
+                    "version": "2.72",
+                    "code": "19600-6",
+                    "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
                   }
                 ]
               },
@@ -303,9 +303,9 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "version": "2.68",
-                    "code": "11246-6",
-                    "display": "oxyCODONE (U) [Mass/Vol]"
+                    "version": "2.72",
+                    "code": "19600-6",
+                    "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
                   }
                 ]
               },
@@ -365,9 +365,9 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "version": "2.68",
-                    "code": "11246-6",
-                    "display": "oxyCODONE (U) [Mass/Vol]"
+                    "version": "2.72",
+                    "code": "19600-6",
+                    "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
                   }
                 ]
               },

--- a/input/pagecontent/requests/OpioidCDSREC10PatientView/request-example-rec-10-patient-view-2-illicit-drugs.json
+++ b/input/pagecontent/requests/OpioidCDSREC10PatientView/request-example-rec-10-patient-view-2-illicit-drugs.json
@@ -404,9 +404,9 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "version": "2.68",
-                    "code": "11246-6",
-                    "display": "oxyCODONE (U) [Mass/Vol]"
+                    "version": "2.72",
+                    "code": "19600-6",
+                    "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
                   }
                 ]
               },

--- a/input/pagecontent/requests/OpioidCDSREC10PatientView/request-example-rec-10-patient-view-POS-Cocaine.json
+++ b/input/pagecontent/requests/OpioidCDSREC10PatientView/request-example-rec-10-patient-view-POS-Cocaine.json
@@ -290,7 +290,7 @@
               "subject": {
                 "reference": "Patient/example-rec-10-patient-view-POS-Cocaine-drugs"
               },
-              "effectiveDateTime": "2021-04-29",
+              "effectiveDateTime": "2022-04-29",
               "valueString": "POS",
               "interpretation": [
                 {
@@ -351,7 +351,7 @@
               "subject": {
                 "reference": "Patient/example-rec-10-patient-view-POS-Cocaine-drugs"
               },
-              "effectiveDateTime": "2021-06-06",
+              "effectiveDateTime": "2022-06-06",
               "valueString": "NEG",
               "interpretation": [
                 {
@@ -474,7 +474,7 @@
               "subject": {
                 "reference": "Patient/example-rec-10-patient-view-POS-Cocaine-drugs"
               },
-              "effectiveDateTime": "2021-05-31",
+              "effectiveDateTime": "2022-05-31",
               "valueString": "POS",
               "interpretation": [
                 {

--- a/input/pagecontent/requests/OpioidCDSREC10PatientView/request-example-rec-10-patient-view-illicit-drugs-POS-Opiate.json
+++ b/input/pagecontent/requests/OpioidCDSREC10PatientView/request-example-rec-10-patient-view-illicit-drugs-POS-Opiate.json
@@ -146,9 +146,9 @@
                 "coding": [
                   {
                     "system": "http://loinc.org",
-                    "version": "2.68",
-                    "code": "11246-6",
-                    "display": "oxyCODONE (U) [Mass/Vol]"
+                    "version": "2.72",
+                    "code": "19600-6",
+                    "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
                   }
                 ]
               },

--- a/input/pagecontent/requests/OpioidCDSREC10PatientView/request-example-rec-10-patient-view-illicit-drugs.json
+++ b/input/pagecontent/requests/OpioidCDSREC10PatientView/request-example-rec-10-patient-view-illicit-drugs.json
@@ -264,7 +264,16 @@
           }
         ],
         "status": "final",
-        "code": {
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "laboratory"
+              }
+            ]
+          }
+        ],        "code": {
           "coding": [
             {
               "system": "http://loinc.org",


### PR DESCRIPTION
We should be using the valueset OSUDST instead of ODUS for opiate urine screening. cql and requests updated to do this.