### PR TITLE
MME cautionary language update

### DIFF
--- a/_genonce.sh
+++ b/_genonce.sh
@@ -14,6 +14,8 @@ fi
 
 echo "$txoption"
 
+export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Dfile.encoding=UTF-8"
+
 publisher=$input_cache_path/$publisher_jar
 if test -f "$publisher"; then
 	java -jar $publisher -ig . $txoption $*

--- a/input-cache/txcache/http___fhir.org_guides_cdc_opioid-cds_CodeSystem_opioidcds-indicator.cache
+++ b/input-cache/txcache/http___fhir.org_guides_cdc_opioid-cds_CodeSystem_opioidcds-indicator.cache
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------------------------
-{"hierarchical" : true, "valueSet" :{
+{"hierarchical" : false, "valueSet" :{
   "resourceType" : "ValueSet",
   "compose" : {
     "inactive" : true,
@@ -21,11 +21,54 @@
   }
 }}####
 e: {
-  "error" : "Error from server: Unable to provide support for code system http://fhir.org/guides/cdc/opioid-cds/CodeSystem/opioidcds-indicator"
-}
--------------------------------------------------------------------------------------
-{"hierarchical" : true, "url": "http://fhir.org/guides/cdc/opioid-cds/ValueSet/opioidcds-indicator", "version": "0.1.1"}####
-e: {
-  "error" : "Error from server: Unable to provide support for code system http://fhir.org/guides/cdc/opioid-cds/CodeSystem/opioidcds-indicator"
+  "valueSet" : {
+  "resourceType" : "ValueSet",
+  "language" : "en",
+  "status" : "active",
+  "expansion" : {
+    "identifier" : "urn:uuid:8969b3f7-ebf0-4f41-ab0d-8f18132817f2",
+    "timestamp" : "2023-02-08T01:25:08.371Z",
+    "parameter" : [{
+      "name" : "limitedExpansion",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "excludeNested",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "version",
+      "valueUri" : "http://fhir.org/guides/cdc/opioid-cds/CodeSystem/opioidcds-indicator|2016.4.0"
+    }],
+    "contains" : [{
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Indicates that the workflow result is informational"
+      }],
+      "system" : "http://fhir.org/guides/cdc/opioid-cds/CodeSystem/opioidcds-indicator",
+      "code" : "info",
+      "display" : "Information"
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Indicates that the workflow result is a warning"
+      }],
+      "system" : "http://fhir.org/guides/cdc/opioid-cds/CodeSystem/opioidcds-indicator",
+      "code" : "warning",
+      "display" : "Warning"
+    },
+    {
+      "extension" : [{
+        "url" : "http://hl7.org/fhir/StructureDefinition/valueset-definition",
+        "valueString" : "Indicates that the workflow should not be allowed to proceed"
+      }],
+      "system" : "http://fhir.org/guides/cdc/opioid-cds/CodeSystem/opioidcds-indicator",
+      "code" : "hard-stop",
+      "display" : "Hard Stop"
+    }]
+  }
+},
+  "error" : ""
 }
 -------------------------------------------------------------------------------------

--- a/input-cache/txcache/loinc.cache
+++ b/input-cache/txcache/loinc.cache
@@ -241,3 +241,45 @@ v: {
   "system" : "http://loinc.org"
 }
 -------------------------------------------------------------------------------------
+{"hierarchical" : false, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "inactive" : true,
+    "include" : [{
+      "system" : "http://loinc.org",
+      "concept" : [{
+        "code" : "80764-4"
+      }]
+    }]
+  }
+}}####
+e: {
+  "valueSet" : {
+  "resourceType" : "ValueSet",
+  "language" : "en",
+  "status" : "active",
+  "expansion" : {
+    "identifier" : "urn:uuid:2dfe723a-d5d2-4614-b3a0-d8e1ef7882c1",
+    "timestamp" : "2023-02-07T20:41:01.308Z",
+    "parameter" : [{
+      "name" : "limitedExpansion",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "excludeNested",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "version",
+      "valueUri" : "http://loinc.org|2.73"
+    }],
+    "contains" : [{
+      "system" : "http://loinc.org",
+      "code" : "80764-4",
+      "display" : "Pain medicine Plan of care note"
+    }]
+  }
+},
+  "error" : ""
+}
+-------------------------------------------------------------------------------------

--- a/input-cache/txcache/snomed.cache
+++ b/input-cache/txcache/snomed.cache
@@ -1571,3 +1571,218 @@ v: {
   "system" : "http://snomed.info/sct"
 }
 -------------------------------------------------------------------------------------
+{"hierarchical" : false, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "inactive" : true,
+    "include" : [{
+      "system" : "http://snomed.info/sct",
+      "version" : "http://snomed.info/sct/731000124108",
+      "concept" : [{
+        "code" : "460831000124102"
+      }]
+    }]
+  }
+}}####
+e: {
+  "valueSet" : {
+  "resourceType" : "ValueSet",
+  "language" : "en",
+  "status" : "active",
+  "expansion" : {
+    "identifier" : "urn:uuid:c09444e0-89d4-456f-9aa6-6cc6a62ba565",
+    "timestamp" : "2023-02-07T20:40:58.167Z",
+    "parameter" : [{
+      "name" : "limitedExpansion",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "excludeNested",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "version",
+      "valueUri" : "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20220901"
+    }],
+    "contains" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "460831000124102",
+      "display" : "Counseling about opioid safety (procedure)"
+    }]
+  }
+},
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : false, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "inactive" : true,
+    "include" : [{
+      "system" : "http://snomed.info/sct",
+      "version" : "http://snomed.info/sct/731000124108",
+      "concept" : [{
+        "code" : "454281000124100"
+      }]
+    }]
+  }
+}}####
+e: {
+  "valueSet" : {
+  "resourceType" : "ValueSet",
+  "language" : "en",
+  "status" : "active",
+  "expansion" : {
+    "identifier" : "urn:uuid:379c1d80-d779-4603-8083-0bbfd421ead1",
+    "timestamp" : "2023-02-07T20:41:01.933Z",
+    "parameter" : [{
+      "name" : "limitedExpansion",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "excludeNested",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "version",
+      "valueUri" : "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20220901"
+    }],
+    "contains" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "454281000124100",
+      "display" : "Assessment of risk for opioid abuse (procedure)"
+    }]
+  }
+},
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : false, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "inactive" : true,
+    "include" : [{
+      "system" : "http://snomed.info/sct",
+      "version" : "http://snomed.info/sct/731000124108",
+      "concept" : [{
+        "code" : "461621000124108"
+      }]
+    }]
+  }
+}}####
+e: {
+  "valueSet" : {
+  "resourceType" : "ValueSet",
+  "language" : "en",
+  "status" : "active",
+  "expansion" : {
+    "identifier" : "urn:uuid:7e081129-8e26-4d89-8c27-621da16ea742",
+    "timestamp" : "2023-02-07T20:41:03.026Z",
+    "parameter" : [{
+      "name" : "limitedExpansion",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "excludeNested",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "version",
+      "valueUri" : "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20220901"
+    }],
+    "contains" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "461621000124108",
+      "display" : "Review of prescription drug monitoring program record"
+    }]
+  }
+},
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : false, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "inactive" : true,
+    "include" : [{
+      "system" : "http://snomed.info/sct",
+      "version" : "http://snomed.info/sct/731000124108",
+      "concept" : [{
+        "code" : "408957008"
+      }]
+    }]
+  }
+}}####
+e: {
+  "valueSet" : {
+  "resourceType" : "ValueSet",
+  "language" : "en",
+  "status" : "active",
+  "expansion" : {
+    "identifier" : "urn:uuid:ceb7387b-30fe-4317-9e2a-bc5603b539cb",
+    "timestamp" : "2023-02-07T20:41:03.792Z",
+    "parameter" : [{
+      "name" : "limitedExpansion",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "excludeNested",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "version",
+      "valueUri" : "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20220901"
+    }],
+    "contains" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "408957008",
+      "display" : "Chronic pain control management (procedure)"
+    }]
+  }
+},
+  "error" : ""
+}
+-------------------------------------------------------------------------------------
+{"hierarchical" : false, "valueSet" :{
+  "resourceType" : "ValueSet",
+  "compose" : {
+    "inactive" : true,
+    "include" : [{
+      "system" : "http://snomed.info/sct",
+      "version" : "http://snomed.info/sct/731000124108",
+      "concept" : [{
+        "code" : "461651000124104"
+      }]
+    }]
+  }
+}}####
+e: {
+  "valueSet" : {
+  "resourceType" : "ValueSet",
+  "language" : "en",
+  "status" : "active",
+  "expansion" : {
+    "identifier" : "urn:uuid:b7e5010f-4985-42e5-9827-c379a2eb4eab",
+    "timestamp" : "2023-02-07T20:41:04.479Z",
+    "parameter" : [{
+      "name" : "limitedExpansion",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "excludeNested",
+      "valueBoolean" : true
+    },
+    {
+      "name" : "version",
+      "valueUri" : "http://snomed.info/sct|http://snomed.info/sct/731000124108/version/20220901"
+    }],
+    "contains" : [{
+      "system" : "http://snomed.info/sct",
+      "code" : "461651000124104",
+      "display" : "Review of prescription drug monitoring program record done (situation)"
+    }]
+  }
+},
+  "error" : ""
+}
+-------------------------------------------------------------------------------------

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -59,12 +59,37 @@ service, refer to the [Service Documentation](service-documentation.html).
 
 ### Morphine Milligram Equivalent (MME) Calculation Cautions
 
-> **Caution**: Do not use the calculated dose in MMEs to determine dosage for converting one opioid to another--the new opioid should be dosed lower to avoid unintentional overdose caused by incomplete cross-tolerance and individual differences in opioid pharmacokinetics. Consult the medication label.
+> **Caution**: All doses are in mg/day except for fentanyl, which is mcg/hr. 
 
-> **Caution**: Dosage thresholds in the 2016 CDC Guideline are based on overdose risk when opioids are prescribed for pain and should not guide dosing of medication treatment for opioid use disorder (i.e., medication-assisted treatment [MAT]).
+> **Caution**: Equianalgesic dose conversions are only estimates and cannot account for individual variability in genetics and pharmacokinetics. 
 
-> **Caution**: Tapentadol is a mu-opioid receptor agonist and norepinephrine reuptake inhibitor. MMEs are based on degree of mu-opioid receptor agonist activity, but it is unknown if this drug is associated with overdose in the same dose-dependent manner as observed with medications that are solely mu-opioid receptor agonists.
+> **Caution**: Do not use the calculated dose in MMEs to determine the doses to use when converting one opioid to another; when converting opioids, the new opioid is typically dosed at a substantially lower dose than the calculated MME dose to avoid overdose because of incomplete cross-tolerance and individual variability in opioid pharmacokinetics. Consult the FDA approved product labeling for specific guidance on medications.
 
-> **Extra Caution**:
-> * Methadone: the conversion factor increases at higher doses (Note: this caution is specific to the 2016 CDC Guideline - graduated Methadone conversion factors are not present in the 2022 CDC Clinical Practice Guideline)
-> * Fentanyl: dosed in mcg/hr instead of mg/day, and absorption is affected by heat and other factors.
+> **Caution**: Use particular caution with methadone dose conversions because methadone has a long and variable half-life, and peak respiratory depressant effect occurs later and lasts longer than peak analgesic effect. 
+
+> **Caution**: Use particular caution with transdermal fentanyl because it is dosed in mcg/hr instead of mg/day, and its absorption is affected by heat and other factors. 
+
+> **Caution**: Buprenorphine products approved for the treatment of pain are not included in the table because of their partial µ-receptor agonist activity and resultant ceiling effects compared with full µ-receptor agonists. 
+
+> **Caution**: These conversion factors should not be applied to dosage decisions related to the management of opioid use disorder.
+
+#### Morphine milligram equivalent doses for commonly prescribed opioids for pain management table
+
+| Opioid                           | Conversion Factor |
+|----------------------------------|:-----------------:|
+| Codeine                          | 0.15 |
+| Fentanyl transdermal (in mcg/hr) | 2.4 |
+| Hydrocodone                      | 1.0 |
+| Hydromorphone                    | 5.0 |
+| Methadone                        | 4.7 |
+| Morphine                         | 1.0 |
+| Oxycodone                        | 1.5 |
+| Oxymorphone                      | 3.0 |
+| Tapentadol [^1]                  | 0.4 |
+| Tramadol [^2]                    | 0.2 |
+{: .grid }
+
+[^1]: Tapentadol is a µ-receptor agonist and norepinephrine reuptake inhibitor. MMEs are based on degree of µ-receptor agonist activity; however, it is unknown whether tapentadol is associated with overdose in the same dose-dependent manner as observed with medications that are solely µ-receptor agonists.
+
+[^2]: Tramadol is a µ-receptor agonist and norepinephrine and serotonin reuptake inhibitor. MMEs are based on degree of µ-receptor agonist activity; however, it is unknown whether tramadol is associated with overdose in the same dose-dependent manner as observed with medications that are solely µ-receptor agonists.
+


### PR DESCRIPTION
Resolution for request from CDC for 2016 and 2022 versions of the guideline to use the 2022 language.
Updated MME caution language and added conversion table for commonly prescribed opioids with footnotes