### PR TITLE
Removed CDC ValueSet profile references from ValueSet resources

### DIFF
--- a/input/vocabulary/valueset/all-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/all-urine-drug-screening-tests.json
@@ -3,7 +3,6 @@
   "id": "all-urine-drug-screening-tests",
   "meta": {
     "profile": [
-      "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset",
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset",
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"
     ]

--- a/input/vocabulary/valueset/amphetamine-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/amphetamine-urine-drug-screening-tests.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "amphetamine-urine-drug-screening-tests",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/amphetamines-class-medications.json
+++ b/input/vocabulary/valueset/amphetamines-class-medications.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "amphetamines-class-medications",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/barbiturate-medications.json
+++ b/input/vocabulary/valueset/barbiturate-medications.json
@@ -3,7 +3,6 @@
   "id": "barbiturate-medications",
   "meta": {
     "profile": [
-      "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset",
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset",
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"
     ]

--- a/input/vocabulary/valueset/benzodiazepine-medications.json
+++ b/input/vocabulary/valueset/benzodiazepine-medications.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "benzodiazepine-medications",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/buprenorphine-and-methadone-medications.json
+++ b/input/vocabulary/valueset/buprenorphine-and-methadone-medications.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "buprenorphine-and-methadone-medications",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/buprenorphine-medications.json
+++ b/input/vocabulary/valueset/buprenorphine-medications.json
@@ -3,7 +3,6 @@
   "id": "buprenorphine-medications",
   "meta": {
     "profile": [
-      "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset",
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset",
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"
     ]

--- a/input/vocabulary/valueset/cannabinoid-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/cannabinoid-urine-drug-screening-tests.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "cannabinoid-urine-drug-screening-tests",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/cdc-malignant-cancer-conditions.json
+++ b/input/vocabulary/valueset/cdc-malignant-cancer-conditions.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "cdc-malignant-cancer-conditions",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/cns-depressant-medications.json
+++ b/input/vocabulary/valueset/cns-depressant-medications.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "cns-depressant-medications",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/cocaine-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/cocaine-urine-drug-screening-tests.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "cocaine-urine-drug-screening-tests",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/conditions-documenting-sleep-disordered-breathing.json
+++ b/input/vocabulary/valueset/conditions-documenting-sleep-disordered-breathing.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "conditions-documenting-sleep-disordered-breathing",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-keyWord",

--- a/input/vocabulary/valueset/conditions-documenting-substance-misuse.json
+++ b/input/vocabulary/valueset/conditions-documenting-substance-misuse.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "conditions-documenting-substance-misuse",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/conditions-likely-terminal-for-opioid-prescribing.json
+++ b/input/vocabulary/valueset/conditions-likely-terminal-for-opioid-prescribing.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "conditions-likely-terminal-for-opioid-prescribing",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/extended-release-opioid-with-ambulatory-misuse-potential.json
+++ b/input/vocabulary/valueset/extended-release-opioid-with-ambulatory-misuse-potential.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "extended-release-opioid-with-ambulatory-misuse-potential",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/fentanyl-type-medications.json
+++ b/input/vocabulary/valueset/fentanyl-type-medications.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "fentanyl-type-medications",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/fentanyl-type-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/fentanyl-type-urine-drug-screening-tests.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "fentanyl-type-urine-drug-screening-tests",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/general-opiate-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/general-opiate-urine-drug-screening-tests.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "general-opiate-urine-drug-screening-tests",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/hospice-finding.json
+++ b/input/vocabulary/valueset/hospice-finding.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "hospice-finding",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/hospice-procedure.json
+++ b/input/vocabulary/valueset/hospice-procedure.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "hospice-procedure",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/limited-life-expectancy-conditions.json
+++ b/input/vocabulary/valueset/limited-life-expectancy-conditions.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "limited-life-expectancy-conditions",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/methadone-medications.json
+++ b/input/vocabulary/valueset/methadone-medications.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "methadone-medications",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/methadone-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/methadone-urine-drug-screening-tests.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "methadone-urine-drug-screening-tests",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/naloxone-medications.json
+++ b/input/vocabulary/valueset/naloxone-medications.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "naloxone-medications",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/non-opioid-urine-drug-screening.json
+++ b/input/vocabulary/valueset/non-opioid-urine-drug-screening.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "non-opioid-urine-drug-screening",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/non-synthetic-opioid-medications.json
+++ b/input/vocabulary/valueset/non-synthetic-opioid-medications.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "non-synthetic-opioid-medications",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/oncology-specialty-designations.json
+++ b/input/vocabulary/valueset/oncology-specialty-designations.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "oncology-specialty-designations",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/opiate-specific-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/opiate-specific-urine-drug-screening-tests.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "opiate-specific-urine-drug-screening-tests",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/opioid-analgesics-with-ambulatory-misuse-potential.json
+++ b/input/vocabulary/valueset/opioid-analgesics-with-ambulatory-misuse-potential.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "opioid-analgesics-with-ambulatory-misuse-potential",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/opioid-counseling-procedure.json
+++ b/input/vocabulary/valueset/opioid-counseling-procedure.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "opioid-counseling-procedure",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/opioid-misuse-assessment-procedure.json
+++ b/input/vocabulary/valueset/opioid-misuse-assessment-procedure.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "opioid-misuse-assessment-procedure",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/opioid-misuse-disorders.json
+++ b/input/vocabulary/valueset/opioid-misuse-disorders.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "opioid-misuse-disorders",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/opioid-treatment-assessment-procedure.json
+++ b/input/vocabulary/valueset/opioid-treatment-assessment-procedure.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "opioid-treatment-assessment-procedure",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/opioid-urine-drug-screening.json
+++ b/input/vocabulary/valueset/opioid-urine-drug-screening.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "opioid-urine-drug-screening",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/oxycodone-medications.json
+++ b/input/vocabulary/valueset/oxycodone-medications.json
@@ -3,7 +3,6 @@
   "id": "oxycodone-medications",
   "meta": {
     "profile": [
-      "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset",
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset",
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"
     ]

--- a/input/vocabulary/valueset/pain-management-procedure.json
+++ b/input/vocabulary/valueset/pain-management-procedure.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "pain-management-procedure",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/pain-treatment-plan.json
+++ b/input/vocabulary/valueset/pain-treatment-plan.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "pain-treatment-plan",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/pdmp-data-reviewed-finding.json
+++ b/input/vocabulary/valueset/pdmp-data-reviewed-finding.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "pdmp-data-reviewed-finding",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/pdmp-review-procedure.json
+++ b/input/vocabulary/valueset/pdmp-review-procedure.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "pdmp-review-procedure",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-author",

--- a/input/vocabulary/valueset/phencyclidine-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/phencyclidine-urine-drug-screening-tests.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "phencyclidine-urine-drug-screening-tests",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/sickle-cell-diseases.json
+++ b/input/vocabulary/valueset/sickle-cell-diseases.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "sickle-cell-diseases",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/substance-misuse-behavioral-counseling.json
+++ b/input/vocabulary/valueset/substance-misuse-behavioral-counseling.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "substance-misuse-behavioral-counseling",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/synthetic-opioid-medications.json
+++ b/input/vocabulary/valueset/synthetic-opioid-medications.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "synthetic-opioid-medications",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/synthetic-opioid-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/synthetic-opioid-urine-drug-screening-tests.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "synthetic-opioid-urine-drug-screening-tests",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/therapies-indicating-end-of-life-care.json
+++ b/input/vocabulary/valueset/therapies-indicating-end-of-life-care.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "therapies-indicating-end-of-life-care",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset-clinical-focus",

--- a/input/vocabulary/valueset/valueset-condition-clinical-status-active.json
+++ b/input/vocabulary/valueset/valueset-condition-clinical-status-active.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "condition-clinical-status-active",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [
     {

--- a/input/vocabulary/valueset/valueset-condition-encounter-diagnosis-category.json
+++ b/input/vocabulary/valueset/valueset-condition-encounter-diagnosis-category.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "condition-encounter-diagnosis-category",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [
     {

--- a/input/vocabulary/valueset/valueset-condition-problem-list-category.json
+++ b/input/vocabulary/valueset/valueset-condition-problem-list-category.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "condition-problem-list-category",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [
     {

--- a/input/vocabulary/valueset/valueset-condition-us-core-health-concern-category.json
+++ b/input/vocabulary/valueset/valueset-condition-us-core-health-concern-category.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "condition-us-core-health-concern-category",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [
     {

--- a/input/vocabulary/valueset/valueset-hospice-disposition.json
+++ b/input/vocabulary/valueset/valueset-hospice-disposition.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "hospice-disposition",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",

--- a/input/vocabulary/valueset/valueset-observation-category-laboratory.json
+++ b/input/vocabulary/valueset/valueset-observation-category-laboratory.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "observation-category-laboratory",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [
     {

--- a/input/vocabulary/valueset/valueset-observation-category-procedure.json
+++ b/input/vocabulary/valueset/valueset-observation-category-procedure.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "observation-category-procedure",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [
     {

--- a/input/vocabulary/valueset/valueset-office-visit.json
+++ b/input/vocabulary/valueset/valueset-office-visit.json
@@ -2,7 +2,7 @@
   "resourceType": "ValueSet",
   "id": "office-visit",
   "meta": {
-    "profile": [ "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset", "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
+    "profile": [ "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset" ]
   },
   "extension": [ {
     "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-knowledgeCapability",

--- a/input/vocabulary/valueset/xylazine-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/xylazine-urine-drug-screening-tests.json
@@ -3,7 +3,6 @@
   "id": "xylazine-urine-drug-screening-tests",
   "meta": {
     "profile": [
-      "http://fhir.org/guides/cdc/opioid-cds/StructureDefinition/cdc-valueset",
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset",
       "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"
     ]


### PR DESCRIPTION
Was causing issue with ValueSets being incorrectly labelled as examples in the IG. This profile should be defined elsewhere. Perhaps the opioid data exchange IG?