### PR TITLE
Valueset phencyclidine-urine-drug-screening-tests updated

### DIFF
--- a/input/vocabulary/valueset/phencyclidine-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/phencyclidine-urine-drug-screening-tests.json
@@ -127,78 +127,695 @@
     ]
   },
   "expansion": {
-    "timestamp": "2023-05-25T18:08:12-06:00",
-    "total": 14,
-    "contains": [ {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "3937-0",
-      "display": "Phencyclidine [Mass/volume] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "16254-5",
-      "display": "Phencyclidine [Mass/volume] in Urine by Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "72825-3",
-      "display": "Phencyclidine [Mass/volume] in Urine by Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "3936-2",
-      "display": "Phencyclidine [Presence] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "18392-1",
-      "display": "Phencyclidine [Presence] in Urine by Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "14311-5",
-      "display": "Phencyclidine [Presence] in Urine by Confirm method >20 ng/mL"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "8237-0",
-      "display": "Phencyclidine [Presence] in Urine by SAMHSA confirm method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "8238-8",
-      "display": "Phencyclidine [Presence] in Urine by SAMHSA screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "19659-2",
-      "display": "Phencyclidine [Presence] in Urine by Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "14310-7",
-      "display": "Phencyclidine [Presence] in Urine by Screen method >25 ng/mL"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "52951-1",
-      "display": "Phencyclidine [Moles/volume] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "19661-8",
-      "display": "Phencyclidine cutoff [Mass/volume] in Urine for Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "19660-0",
-      "display": "Phencyclidine cutoff [Mass/volume] in Urine for Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.74",
-      "code": "58397-1",
-      "display": "Phencyclidine/Creatinine [Mass Ratio] in Urine"
-    } ]
+    "timestamp": "2026-04-29T15:25:48.416Z",
+    "parameter": [
+      {
+        "name": "offset",
+        "valueInteger": 0
+      },
+      {
+        "name": "count",
+        "valueInteger": 200
+      },
+      {
+        "name": "used-codesystem",
+        "valueUri": "http://loinc.org|2.82"
+      }
+    ],
+    "offset": 0,
+    "total": 95,
+    "contains": [
+      {
+        "system": "http://loinc.org",
+        "code": "3372-0",
+        "display": "Barbiturate screen absent [Identifier] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3373-8",
+        "display": "Deprecated Barbiturate screen absent [Identifier] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "DEPRECATED"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3374-6",
+        "display": "Barbiturate screen present [Identifier] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3375-3",
+        "display": "Deprecated Barbiturate screen present [Identifier] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "DEPRECATED"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19274-0",
+        "display": "Barbiturates positive [Identifier] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "12360-4",
+        "display": "Barbital [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19353-2",
+        "display": "Barbital [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19354-0",
+        "display": "Barbital [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19355-7",
+        "display": "Barbital cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19356-5",
+        "display": "Barbital cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20518-7",
+        "display": "Barbital [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3371-2",
+        "display": "Barbital [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16429-3",
+        "display": "Barbiturates [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16430-1",
+        "inactive": true,
+        "display": "Barbiturates [Units/volume] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "DISCOURAGED"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19270-8",
+        "display": "Barbiturates [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19271-6",
+        "display": "Barbiturates tested for in Urine by Screen method Nominal"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19272-4",
+        "display": "Barbiturates tested for in Urine by Screen method Narrative"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19275-7",
+        "display": "Barbiturates cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19276-5",
+        "display": "Barbiturates cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19277-3",
+        "display": "Barbiturates screen method [Identifier] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19278-1",
+        "display": "Barbiturates confirm method [Identifier] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20411-5",
+        "display": "Barbiturates [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20664-9",
+        "display": "Barbiturates [Mass/volume] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3377-9",
+        "display": "Barbiturates [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "41468-0",
+        "display": "Barbiturates/Creatinine [Mass Ratio] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "52956-0",
+        "display": "Barbiturates [Moles/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "70139-1",
+        "display": "Barbiturates [Presence] in Urine by Screen method >300 ng/mL"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "70155-7",
+        "display": "Barbiturates [Presence] in Urine by Screen method >200 ng/mL"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "9426-8",
+        "display": "Barbiturates [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16191-9",
+        "display": "Butabarbital [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16236-2",
+        "display": "Butabarbital [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19368-0",
+        "display": "Butabarbital [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19370-6",
+        "display": "Butabarbital [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19371-4",
+        "display": "Butabarbital cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19372-2",
+        "display": "Butabarbital cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3419-9",
+        "display": "Butabarbital [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "11071-8",
+        "display": "Butalbital [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16237-0",
+        "display": "Butalbital [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "18385-5",
+        "display": "Butalbital [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19373-0",
+        "display": "Butalbital [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19375-5",
+        "display": "Butalbital cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19376-3",
+        "display": "Butalbital cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "32056-4",
+        "display": "Butalbital [Moles/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3421-5",
+        "display": "Butalbital [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "64139-9",
+        "display": "Butalbital/Creatinine [Mass Ratio] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "27165-0",
+        "display": "Hexobarbital [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "12315-8",
+        "display": "Mephobarbital [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "17250-2",
+        "display": "Mephobarbital [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19536-2",
+        "display": "Mephobarbital [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19537-0",
+        "display": "Mephobarbital [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19539-6",
+        "display": "Mephobarbital [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19540-4",
+        "display": "Mephobarbital cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19541-2",
+        "display": "Mephobarbital cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3920-6",
+        "display": "Pentetrazol [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3921-4",
+        "display": "Pentetrazol [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3922-2",
+        "display": "Pentetrazol [Mass/time] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16193-5",
+        "display": "PENTobarbital [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16240-4",
+        "display": "PENTobarbital [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19655-0",
+        "display": "PENTobarbital [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19657-6",
+        "display": "PENTobarbital cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19658-4",
+        "display": "PENTobarbital cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3925-5",
+        "display": "PENTobarbital [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3926-3",
+        "display": "PENTobarbital [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "64132-4",
+        "display": "PENTobarbital/Creatinine [Mass Ratio] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16192-7",
+        "display": "PHENobarbital [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16241-2",
+        "display": "PHENobarbital [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19666-7",
+        "display": "PHENobarbital [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19668-3",
+        "display": "PHENobarbital cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19669-1",
+        "display": "PHENobarbital cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "39487-4",
+        "display": "PHENobarbital [Moles/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3949-5",
+        "display": "PHENobarbital [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3950-3",
+        "display": "PHENobarbital [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "64133-2",
+        "display": "PHENobarbital/Creatinine [Mass Ratio] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16194-3",
+        "display": "Secobarbital [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16238-8",
+        "display": "Secobarbital [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19692-3",
+        "display": "Secobarbital [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19695-6",
+        "display": "Secobarbital [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19696-4",
+        "display": "Secobarbital cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19697-2",
+        "display": "Secobarbital cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "4029-5",
+        "display": "Secobarbital [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "72928-5",
+        "display": "Secobarbital [Moles/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "12370-3",
+        "display": "Thiopental [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16223-0",
+        "display": "Thiopental [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53735-7",
+        "display": "Barbiturates.other [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "53746-4",
+        "display": "Barbiturates panel - Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "110546-9",
+        "display": "Barbital [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "111449-5",
+        "display": "Barbiturates [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "110552-7",
+        "display": "Butabarbital [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "111149-1",
+        "display": "Butalbital [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "110579-0",
+        "display": "Mephobarbital [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "108490-4",
+        "display": "Pentetrazol [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "110585-7",
+        "display": "PENTobarbital [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "111121-0",
+        "display": "PHENobarbital [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "111096-4",
+        "display": "Secobarbital [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "64135-7",
+        "display": "Secobarbital/Creatinine [Mass Ratio] of Urine"
+      }
+    ],
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.property",
+        "extension": [
+          {
+            "url": "code",
+            "valueCode": "status"
+          },
+          {
+            "url": "uri",
+            "valueUri": "http://hl7.org/fhir/concept-properties#status"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/input/vocabulary/valueset/phencyclidine-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/phencyclidine-urine-drug-screening-tests.json
@@ -124,7 +124,8 @@
     ]
   },
   "expansion": {
-    "timestamp": "2026-04-29T15:25:48.416Z",
+    "timestamp": "2026-04-30T19:08:24.144Z",
+    "identifier": "urn:uuid:46e4fba3-2cef-4f83-97dd-ca61d9c0cc90",
     "parameter": [
       {
         "name": "offset",
@@ -140,483 +141,82 @@
       }
     ],
     "offset": 0,
-    "total": 95,
+    "total": 15,
     "contains": [
       {
         "system": "http://loinc.org",
-        "code": "3372-0",
-        "display": "Barbiturate screen absent [Identifier] in Urine"
+        "code": "14310-7",
+        "display": "Phencyclidine [Presence] in Urine by Screen method >25 ng/mL"
       },
       {
         "system": "http://loinc.org",
-        "code": "3373-8",
-        "display": "Deprecated Barbiturate screen absent [Identifier] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "DEPRECATED"
-              }
-            ]
-          }
-        ]
+        "code": "14311-5",
+        "display": "Phencyclidine [Presence] in Urine by Confirm method >20 ng/mL"
       },
       {
         "system": "http://loinc.org",
-        "code": "3374-6",
-        "display": "Barbiturate screen present [Identifier] in Urine"
+        "code": "16254-5",
+        "display": "Phencyclidine [Mass/volume] in Urine by Confirmatory method"
       },
       {
         "system": "http://loinc.org",
-        "code": "3375-3",
-        "display": "Deprecated Barbiturate screen present [Identifier] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "DEPRECATED"
-              }
-            ]
-          }
-        ]
+        "code": "18392-1",
+        "display": "Phencyclidine [Presence] in Urine by Confirmatory method"
       },
       {
         "system": "http://loinc.org",
-        "code": "19274-0",
-        "display": "Barbiturates positive [Identifier] in Urine by Confirmatory method"
+        "code": "19659-2",
+        "display": "Phencyclidine [Presence] in Urine by Screen method"
       },
       {
         "system": "http://loinc.org",
-        "code": "12360-4",
-        "display": "Barbital [Presence] in Urine"
+        "code": "19660-0",
+        "display": "Phencyclidine cutoff [Mass/volume] in Urine for Screen method"
       },
       {
         "system": "http://loinc.org",
-        "code": "19353-2",
-        "display": "Barbital [Presence] in Urine by Screen method"
+        "code": "19661-8",
+        "display": "Phencyclidine cutoff [Mass/volume] in Urine for Confirmatory method"
       },
       {
         "system": "http://loinc.org",
-        "code": "19354-0",
-        "display": "Barbital [Presence] in Urine by Confirmatory method"
+        "code": "3936-2",
+        "display": "Phencyclidine [Presence] in Urine"
       },
       {
         "system": "http://loinc.org",
-        "code": "19355-7",
-        "display": "Barbital cutoff [Mass/volume] in Urine for Screen method"
+        "code": "3937-0",
+        "display": "Phencyclidine [Mass/volume] in Urine"
       },
       {
         "system": "http://loinc.org",
-        "code": "19356-5",
-        "display": "Barbital cutoff [Mass/volume] in Urine for Confirmatory method"
+        "code": "52951-1",
+        "display": "Phencyclidine [Moles/volume] in Urine"
       },
       {
         "system": "http://loinc.org",
-        "code": "20518-7",
-        "display": "Barbital [Mass/volume] in Urine by Confirmatory method"
+        "code": "58397-1",
+        "display": "Phencyclidine/Creatinine [Mass Ratio] in Urine"
       },
       {
         "system": "http://loinc.org",
-        "code": "3371-2",
-        "display": "Barbital [Mass/volume] in Urine"
+        "code": "72825-3",
+        "display": "Phencyclidine [Mass/volume] in Urine by Screen method"
       },
       {
         "system": "http://loinc.org",
-        "code": "16429-3",
-        "display": "Barbiturates [Presence] in Urine by Confirmatory method"
+        "code": "8237-0",
+        "display": "Phencyclidine [Presence] in Urine by SAMHSA confirm method"
       },
       {
         "system": "http://loinc.org",
-        "code": "16430-1",
-        "inactive": true,
-        "display": "Barbiturates [Units/volume] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "DISCOURAGED"
-              }
-            ]
-          }
-        ]
+        "code": "8238-8",
+        "display": "Phencyclidine [Presence] in Urine by SAMHSA screen method"
       },
       {
         "system": "http://loinc.org",
-        "code": "19270-8",
-        "display": "Barbiturates [Presence] in Urine by Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19271-6",
-        "display": "Barbiturates tested for in Urine by Screen method Nominal"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19272-4",
-        "display": "Barbiturates tested for in Urine by Screen method Narrative"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19275-7",
-        "display": "Barbiturates cutoff [Mass/volume] in Urine for Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19276-5",
-        "display": "Barbiturates cutoff [Mass/volume] in Urine for Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19277-3",
-        "display": "Barbiturates screen method [Identifier] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19278-1",
-        "display": "Barbiturates confirm method [Identifier] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "20411-5",
-        "display": "Barbiturates [Mass/volume] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "20664-9",
-        "display": "Barbiturates [Mass/volume] in Urine by Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "3377-9",
-        "display": "Barbiturates [Presence] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "41468-0",
-        "display": "Barbiturates/Creatinine [Mass Ratio] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "52956-0",
-        "display": "Barbiturates [Moles/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "70139-1",
-        "display": "Barbiturates [Presence] in Urine by Screen method >300 ng/mL"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "70155-7",
-        "display": "Barbiturates [Presence] in Urine by Screen method >200 ng/mL"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "9426-8",
-        "display": "Barbiturates [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "16191-9",
-        "display": "Butabarbital [Presence] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "16236-2",
-        "display": "Butabarbital [Mass/volume] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19368-0",
-        "display": "Butabarbital [Presence] in Urine by Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19370-6",
-        "display": "Butabarbital [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19371-4",
-        "display": "Butabarbital cutoff [Mass/volume] in Urine for Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19372-2",
-        "display": "Butabarbital cutoff [Mass/volume] in Urine for Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "3419-9",
-        "display": "Butabarbital [Presence] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "11071-8",
-        "display": "Butalbital [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "16237-0",
-        "display": "Butalbital [Mass/volume] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "18385-5",
-        "display": "Butalbital [Presence] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19373-0",
-        "display": "Butalbital [Presence] in Urine by Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19375-5",
-        "display": "Butalbital cutoff [Mass/volume] in Urine for Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19376-3",
-        "display": "Butalbital cutoff [Mass/volume] in Urine for Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "32056-4",
-        "display": "Butalbital [Moles/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "3421-5",
-        "display": "Butalbital [Presence] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "64139-9",
-        "display": "Butalbital/Creatinine [Mass Ratio] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "27165-0",
-        "display": "Hexobarbital [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "12315-8",
-        "display": "Mephobarbital [Presence] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "17250-2",
-        "display": "Mephobarbital [Mass/volume] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19536-2",
-        "display": "Mephobarbital [Presence] in Urine by Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19537-0",
-        "display": "Mephobarbital [Presence] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19539-6",
-        "display": "Mephobarbital [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19540-4",
-        "display": "Mephobarbital cutoff [Mass/volume] in Urine for Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19541-2",
-        "display": "Mephobarbital cutoff [Mass/volume] in Urine for Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "3920-6",
-        "display": "Pentetrazol [Presence] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "3921-4",
-        "display": "Pentetrazol [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "3922-2",
-        "display": "Pentetrazol [Mass/time] in 24 hour Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "16193-5",
-        "display": "PENTobarbital [Presence] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "16240-4",
-        "display": "PENTobarbital [Mass/volume] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19655-0",
-        "display": "PENTobarbital [Presence] in Urine by Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19657-6",
-        "display": "PENTobarbital cutoff [Mass/volume] in Urine for Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19658-4",
-        "display": "PENTobarbital cutoff [Mass/volume] in Urine for Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "3925-5",
-        "display": "PENTobarbital [Presence] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "3926-3",
-        "display": "PENTobarbital [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "64132-4",
-        "display": "PENTobarbital/Creatinine [Mass Ratio] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "16192-7",
-        "display": "PHENobarbital [Presence] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "16241-2",
-        "display": "PHENobarbital [Mass/volume] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19666-7",
-        "display": "PHENobarbital [Presence] in Urine by Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19668-3",
-        "display": "PHENobarbital cutoff [Mass/volume] in Urine for Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19669-1",
-        "display": "PHENobarbital cutoff [Mass/volume] in Urine for Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "39487-4",
-        "display": "PHENobarbital [Moles/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "3949-5",
-        "display": "PHENobarbital [Presence] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "3950-3",
-        "display": "PHENobarbital [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "64133-2",
-        "display": "PHENobarbital/Creatinine [Mass Ratio] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "16194-3",
-        "display": "Secobarbital [Presence] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "16238-8",
-        "display": "Secobarbital [Mass/volume] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19692-3",
-        "display": "Secobarbital [Presence] in Urine by Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19695-6",
-        "display": "Secobarbital [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19696-4",
-        "display": "Secobarbital cutoff [Mass/volume] in Urine for Screen method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "19697-2",
-        "display": "Secobarbital cutoff [Mass/volume] in Urine for Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "4029-5",
-        "display": "Secobarbital [Presence] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "72928-5",
-        "display": "Secobarbital [Moles/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "12370-3",
-        "display": "Thiopental [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "16223-0",
-        "display": "Thiopental [Presence] in Urine by Confirmatory method"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "53735-7",
-        "display": "Barbiturates.other [Mass/volume] in Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "53746-4",
-        "display": "Barbiturates panel - Urine"
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "110546-9",
-        "display": "Barbital [Measurement] in Urine",
+        "code": "108012-6",
+        "display": "Phencyclidine [Measurement] in Urine",
         "extension": [
           {
             "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
@@ -632,171 +232,6 @@
             ]
           }
         ]
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "111449-5",
-        "display": "Barbiturates [Measurement] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "TRIAL"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "110552-7",
-        "display": "Butabarbital [Measurement] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "TRIAL"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "111149-1",
-        "display": "Butalbital [Measurement] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "TRIAL"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "110579-0",
-        "display": "Mephobarbital [Measurement] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "TRIAL"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "108490-4",
-        "display": "Pentetrazol [Measurement] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "TRIAL"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "110585-7",
-        "display": "PENTobarbital [Measurement] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "TRIAL"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "111121-0",
-        "display": "PHENobarbital [Measurement] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "TRIAL"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "111096-4",
-        "display": "Secobarbital [Measurement] in Urine",
-        "extension": [
-          {
-            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
-            "extension": [
-              {
-                "url": "code",
-                "valueCode": "status"
-              },
-              {
-                "url": "value",
-                "valueCode": "TRIAL"
-              }
-            ]
-          }
-        ]
-      },
-      {
-        "system": "http://loinc.org",
-        "code": "64135-7",
-        "display": "Secobarbital/Creatinine [Mass Ratio] of Urine"
       }
     ],
     "extension": [

--- a/input/vocabulary/valueset/phencyclidine-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/phencyclidine-urine-drug-screening-tests.json
@@ -37,7 +37,21 @@
   }, {
     "url": "http://hl7.org/fhir/StructureDefinition/valueset-rules-text",
     "valueMarkdown": "Use the following LOINC query: Phencyclidine (=system:Urine) AND NOT status:DEPRECATED"
-  } ],
+  },
+  {
+    "url": "http://hl7.org/fhir/StructureDefinition/cqf-artifactComment",
+    "extension": [
+      {
+        "url": "type",
+        "valueCode": "documentation"
+      },
+      {
+        "url": "text",
+        "valueMarkdown": "Maintenance search expression: `Phencyclidine (=system:Urine) AND NOT status:DEPRECATED`. This expression is used as a human-reviewed LOINC hierarchy/search query to identify candidate urine phencyclidine test codes. The compose is curated and may use exact parent, SYSTEM, CLASSTYPE, and COMPONENT filters to avoid false positives such as Dextromethorphan."
+      }
+    ]
+  }
+  ],
   "url": "http://fhir.org/guides/cdc/opioid-cds/ValueSet/phencyclidine-urine-drug-screening-tests",
   "name": "PHENCYCLIDINE_URINE_DRUG_SCREENING_TESTS",
   "title": "Phencyclidine urine drug screening tests",
@@ -61,6 +75,57 @@
   } ],
   "purpose": "Identification of urine drug tests where results can be used when considering pain management therapy",
   "copyright": "© CDC 2016+.",
+  "compose": {
+    "include": [
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP390195-8"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP248770-2"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          },
+          {
+            "property": "COMPONENT",
+            "op": "=",
+            "value": "LP14566-1"
+          }
+        ]
+      }
+    ]
+  },
   "expansion": {
     "timestamp": "2023-05-25T18:08:12-06:00",
     "total": 14,

--- a/input/vocabulary/valueset/phencyclidine-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/phencyclidine-urine-drug-screening-tests.json
@@ -34,9 +34,6 @@
   }, {
     "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-usageWarning",
     "valueString": "This value set contains a point-in-time expansion enumerating the codes that meet the value set intent. As new versions of the code systems used by the value set are released, the contents of this expansion will need to be updated to incorporate newly defined codes that meet the value set intent. Before, and periodically during production use, the value set expansion contents SHOULD be updated. The value set expansion specifies the timestamp when the expansion was produced, SHOULD contain the parameters used for the expansion, and SHALL contain the codes that are obtained by evaluating the value set definition. If this is ONLY an executable value set, a distributable definition of the value set must be obtained to compute the updated expansion."
-  }, {
-    "url": "http://hl7.org/fhir/StructureDefinition/valueset-rules-text",
-    "valueMarkdown": "Use the following LOINC query: Phencyclidine (=system:Urine) AND NOT status:DEPRECATED"
   },
   {
     "url": "http://hl7.org/fhir/StructureDefinition/cqf-artifactComment",


### PR DESCRIPTION
$expand results
{
  "resourceType": "ValueSet",
  "meta": {
    "profile": [
      "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-computablevalueset",
      "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-executablevalueset"
    ]
  },
  "url": "http://fhir.org/guides/cdc/opioid-cds/ValueSet/phencyclidine-urine-drug-screening-tests",
  "name": "PHENCYCLIDINE_URINE_DRUG_SCREENING_TESTS",
  "title": "Phencyclidine urine drug screening tests",
  "status": "active",
  "experimental": false,
  "date": "2023-05-25T18:08:12-06:00",
  "contact": [
    {
      "name": "Centers for Disease Control and Prevention (CDC)",
      "telecom": [
        {
          "system": "url",
          "value": "https://www.cdc.gov"
        }
      ]
    }
  ],
  "jurisdiction": [
    {
      "coding": [
        {
          "system": "urn:iso:std:iso:3166",
          "code": "US"
        }
      ]
    }
  ],
  "expansion": {
    "timestamp": "2023-05-25T18:08:12-06:00",
    "total": 14,
    "contains": [
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "3937-0",
        "display": "Phencyclidine [Mass/volume] in Urine"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "16254-5",
        "display": "Phencyclidine [Mass/volume] in Urine by Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "72825-3",
        "display": "Phencyclidine [Mass/volume] in Urine by Screen method"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "3936-2",
        "display": "Phencyclidine [Presence] in Urine"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "18392-1",
        "display": "Phencyclidine [Presence] in Urine by Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "14311-5",
        "display": "Phencyclidine [Presence] in Urine by Confirm method >20 ng/mL"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "8237-0",
        "display": "Phencyclidine [Presence] in Urine by SAMHSA confirm method"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "8238-8",
        "display": "Phencyclidine [Presence] in Urine by SAMHSA screen method"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "19659-2",
        "display": "Phencyclidine [Presence] in Urine by Screen method"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "14310-7",
        "display": "Phencyclidine [Presence] in Urine by Screen method >25 ng/mL"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "52951-1",
        "display": "Phencyclidine [Moles/volume] in Urine"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "19661-8",
        "display": "Phencyclidine cutoff [Mass/volume] in Urine for Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "19660-0",
        "display": "Phencyclidine cutoff [Mass/volume] in Urine for Screen method"
      },
      {
        "system": "http://loinc.org",
        "version": "2.74",
        "code": "58397-1",
        "display": "Phencyclidine/Creatinine [Mass Ratio] in Urine"
      }
    ]
  }
}