### PR TITLE
opiate uring drug test valueset updated

### DIFF
--- a/input/vocabulary/valueset/opiate-specific-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/opiate-specific-urine-drug-screening-tests.json
@@ -164,7 +164,7 @@
           {
             "property": "parent",
             "op": "=",
-            "value": "LP28826-6"
+            "value": "LP390040-6"
           },
           {
             "property": "SYSTEM",
@@ -250,12 +250,38 @@
             "value": "LP15174-3"
           }
         ]
+      },
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP248770-2"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          },
+          {
+            "property": "COMPONENT",
+            "op": "=",
+            "value": "LP28863-6"
+          }
+        ]
       }
     ]
   },
   "expansion": {
-    "timestamp": "2026-04-30T20:28:42.879Z",
-    "identifier": "urn:uuid:f28ceb75-4362-4e24-ac9c-f2111b497f2f",
+    "timestamp": "2026-05-01T16:41:28.284Z",
+    "identifier": "urn:uuid:e3250cee-b28b-41e9-84f0-003435488721",
     "parameter": [
       {
         "name": "offset",
@@ -271,7 +297,7 @@
       }
     ],
     "offset": 0,
-    "total": 35,
+    "total": 36,
     "contains": [
       {
         "system": "http://loinc.org",
@@ -462,6 +488,26 @@
         "system": "http://loinc.org",
         "code": "111393-5",
         "display": "Morphine [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "110571-7",
+        "display": "Morphine Free [Measurement] in Urine",
         "extension": [
           {
             "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",

--- a/input/vocabulary/valueset/opiate-specific-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/opiate-specific-urine-drug-screening-tests.json
@@ -34,9 +34,19 @@
   }, {
     "url": "http://hl7.org/fhir/uv/cpg/StructureDefinition/cpg-usageWarning",
     "valueString": "This value set contains a point-in-time expansion enumerating the codes that meet the value set intent. As new versions of the code systems used by the value set are released, the contents of this expansion will need to be updated to incorporate newly defined codes that meet the value set intent. Before, and periodically during production use, the value set expansion contents SHOULD be updated. The value set expansion specifies the timestamp when the expansion was produced, SHOULD contain the parameters used for the expansion, and SHALL contain the codes that are obtained by evaluating the value set definition. If this is ONLY an executable value set, a distributable definition of the value set must be obtained to compute the updated expansion."
-  }, {
-    "url": "http://hl7.org/fhir/StructureDefinition/valueset-rules-text",
-    "valueMarkdown": "Step 1. Add all codes found using the following LOINC query: (morphine AND NOT diamorphine AND NOT 6-Monoacetylmorphine) (=system:Urine)"
+  },
+  {
+    "url": "http://hl7.org/fhir/StructureDefinition/cqf-artifactComment",
+    "extension": [
+      {
+        "url": "type",
+        "valueCode": "documentation"
+      },
+      {
+        "url": "text",
+        "valueMarkdown": "Maintenance search expression: `(morphine AND NOT diamorphine AND NOT 6-Monoacetylmorphine) (=system:Urine)`. This expression is used as a human-reviewed LOINC hierarchy/search query to identify candidate urine opiate test codes. The compose is curated and may use exact parent, SYSTEM, CLASSTYPE, and COMPONENT filters to avoid false positives such as from Antibiotics."
+      }
+    ]
   } ],
   "url": "http://fhir.org/guides/cdc/opioid-cds/ValueSet/opiate-specific-urine-drug-screening-tests",
   "name": "OPIATE_SPECIFIC_URINE_DRUG_SCREENING_TESTS",
@@ -61,174 +71,428 @@
   } ],
   "purpose": "Identification of urine drug tests where results can be used when considering pain management therapy",
   "copyright": "© CDC 2016+.",
+  "compose": {
+    "include": [
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP389812-1"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP389858-4"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP389859-2"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP389854-3"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP390040-6"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP390032-3"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP248770-2"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          },
+          {
+            "property": "COMPONENT",
+            "op": "=",
+            "value": "LP16093-4"
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "version": "2.82",
+        "filter": [
+          {
+            "property": "parent",
+            "op": "=",
+            "value": "LP248770-2"
+          },
+          {
+            "property": "SYSTEM",
+            "op": "=",
+            "value": "LP7681-2"
+          },
+          {
+            "property": "CLASSTYPE",
+            "op": "=",
+            "value": "1"
+          },
+          {
+            "property": "COMPONENT",
+            "op": "=",
+            "value": "LP15174-3"
+          }
+        ]
+      }
+    ]
+  },
   "expansion": {
-    "timestamp": "2023-05-25T18:08:12-06:00",
-    "total": 33,
-    "contains": [ {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "89308-1",
-      "display": "Morphine-6-Glucuronide [Presence] in Urine by Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "51739-1",
-      "display": "Codeine Free [Mass/volume] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "89310-7",
-      "display": "Codeine-6-glucuronide [Presence] in Urine by Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "3508-9",
-      "display": "Codeine [Mass/volume] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "16250-3",
-      "display": "Codeine [Mass/volume] in Urine by Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "3507-1",
-      "display": "Codeine [Presence] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "16197-6",
-      "display": "Codeine [Presence] in Urine by Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "13641-6",
-      "display": "Codeine [Presence] in Urine by SAMHSA confirm method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "19411-8",
-      "display": "Codeine [Presence] in Urine by Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "70206-8",
-      "display": "Codeine [Moles/volume] in Urine by Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "19414-2",
-      "display": "Codeine cutoff [Mass/volume] in Urine for Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "19413-4",
-      "display": "Codeine cutoff [Mass/volume] in Urine for Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "58391-4",
-      "display": "Codeine/Creatinine [Mass Ratio] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "3829-9",
-      "display": "Morphine Free [Mass/volume] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "20550-0",
-      "display": "Morphine Free [Mass/volume] in Urine by Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "3828-1",
-      "display": "Morphine Free [Presence] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "19602-2",
-      "display": "Morphine Free [Presence] in Urine by Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "19601-4",
-      "display": "Morphine Free [Presence] in Urine by Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "19604-8",
-      "display": "Morphine Free cutoff [Mass/volume] in Urine for Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "19603-0",
-      "display": "Morphine Free cutoff [Mass/volume] in Urine for Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "3832-3",
-      "display": "Morphine [Mass/time] in 24 hour Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "3831-5",
-      "display": "Morphine [Mass/volume] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "16251-1",
-      "display": "Morphine [Mass/volume] in Urine by Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "3830-7",
-      "display": "Morphine [Presence] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "16196-8",
-      "display": "Morphine [Presence] in Urine by Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "13648-1",
-      "display": "Morphine [Presence] in Urine by SAMHSA confirm method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "19597-4",
-      "display": "Morphine [Presence] in Urine by Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "70210-0",
-      "display": "Morphine [Moles/volume] in Urine by Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "78861-2",
-      "display": "Morphine [Z-score] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "19600-6",
-      "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "19599-0",
-      "display": "Morphine cutoff [Mass/volume] in Urine for Screen method"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "58392-2",
-      "display": "Morphine/Creatinine [Mass Ratio] in Urine"
-    }, {
-      "system": "http://loinc.org",
-      "version": "2.81",
-      "code": "78768-9",
-      "display": "Morphine [Mass/volume] in Urine -- adjusted for lean body mass+urine creatinine"
-    } ]
+    "timestamp": "2026-04-30T20:28:42.879Z",
+    "identifier": "urn:uuid:f28ceb75-4362-4e24-ac9c-f2111b497f2f",
+    "parameter": [
+      {
+        "name": "offset",
+        "valueInteger": 0
+      },
+      {
+        "name": "count",
+        "valueInteger": 200
+      },
+      {
+        "name": "used-codesystem",
+        "valueUri": "http://loinc.org|2.82"
+      }
+    ],
+    "offset": 0,
+    "total": 35,
+    "contains": [
+      {
+        "system": "http://loinc.org",
+        "code": "89308-1",
+        "display": "Morphine-6-Glucuronide [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "51739-1",
+        "display": "Codeine Free [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "89310-7",
+        "display": "Codeine-6-glucuronide [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "13641-6",
+        "display": "Codeine [Presence] in Urine by SAMHSA confirm method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16197-6",
+        "display": "Codeine [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16250-3",
+        "display": "Codeine [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19411-8",
+        "display": "Codeine [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19413-4",
+        "display": "Codeine cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19414-2",
+        "display": "Codeine cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3507-1",
+        "display": "Codeine [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3508-9",
+        "display": "Codeine [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "58391-4",
+        "display": "Codeine/Creatinine [Mass Ratio] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "70206-8",
+        "display": "Codeine [Moles/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19601-4",
+        "display": "Morphine Free [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19602-2",
+        "display": "Morphine Free [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19603-0",
+        "display": "Morphine Free cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19604-8",
+        "display": "Morphine Free cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "20550-0",
+        "display": "Morphine Free [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3828-1",
+        "display": "Morphine Free [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3829-9",
+        "display": "Morphine Free [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "13648-1",
+        "display": "Morphine [Presence] in Urine by SAMHSA confirm method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16196-8",
+        "display": "Morphine [Presence] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "16251-1",
+        "display": "Morphine [Mass/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19597-4",
+        "display": "Morphine [Presence] in Urine by Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19599-0",
+        "display": "Morphine cutoff [Mass/volume] in Urine for Screen method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "19600-6",
+        "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3830-7",
+        "display": "Morphine [Presence] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3831-5",
+        "display": "Morphine [Mass/volume] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "3832-3",
+        "display": "Morphine [Mass/time] in 24 hour Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "58392-2",
+        "display": "Morphine/Creatinine [Mass Ratio] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "70210-0",
+        "display": "Morphine [Moles/volume] in Urine by Confirmatory method"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78768-9",
+        "display": "Morphine [Mass/volume] in Urine -- adjusted for lean body mass+urine creatinine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "78861-2",
+        "display": "Morphine [Z-score] in Urine"
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "111228-3",
+        "display": "Codeine [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "system": "http://loinc.org",
+        "code": "111393-5",
+        "display": "Morphine [Measurement] in Urine",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
+            "extension": [
+              {
+                "url": "code",
+                "valueCode": "status"
+              },
+              {
+                "url": "value",
+                "valueCode": "TRIAL"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.property",
+        "extension": [
+          {
+            "url": "code",
+            "valueCode": "status"
+          },
+          {
+            "url": "uri",
+            "valueUri": "http://hl7.org/fhir/concept-properties#status"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/input/vocabulary/valueset/opiate-specific-urine-drug-screening-tests.json
+++ b/input/vocabulary/valueset/opiate-specific-urine-drug-screening-tests.json
@@ -164,7 +164,7 @@
           {
             "property": "parent",
             "op": "=",
-            "value": "LP390040-6"
+            "value": "LP28826-6"
           },
           {
             "property": "SYSTEM",


### PR DESCRIPTION
"expansion": {
    "timestamp": "2026-04-30T20:28:42.879Z",
    "identifier": "urn:uuid:f28ceb75-4362-4e24-ac9c-f2111b497f2f",
    "parameter": [
      {
        "name": "offset",
        "valueInteger": 0
      },
      {
        "name": "count",
        "valueInteger": 200
      },
      {
        "name": "used-codesystem",
        "valueUri": "http://loinc.org|2.82"
      }
    ],
    "offset": 0,
    "total": 35,
    "contains": [
      {
        "system": "http://loinc.org",
        "code": "89308-1",
        "display": "Morphine-6-Glucuronide [Presence] in Urine by Screen method"
      },
      {
        "system": "http://loinc.org",
        "code": "51739-1",
        "display": "Codeine Free [Mass/volume] in Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "89310-7",
        "display": "Codeine-6-glucuronide [Presence] in Urine by Screen method"
      },
      {
        "system": "http://loinc.org",
        "code": "13641-6",
        "display": "Codeine [Presence] in Urine by SAMHSA confirm method"
      },
      {
        "system": "http://loinc.org",
        "code": "16197-6",
        "display": "Codeine [Presence] in Urine by Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "16250-3",
        "display": "Codeine [Mass/volume] in Urine by Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "19411-8",
        "display": "Codeine [Presence] in Urine by Screen method"
      },
      {
        "system": "http://loinc.org",
        "code": "19413-4",
        "display": "Codeine cutoff [Mass/volume] in Urine for Screen method"
      },
      {
        "system": "http://loinc.org",
        "code": "19414-2",
        "display": "Codeine cutoff [Mass/volume] in Urine for Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "3507-1",
        "display": "Codeine [Presence] in Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "3508-9",
        "display": "Codeine [Mass/volume] in Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "58391-4",
        "display": "Codeine/Creatinine [Mass Ratio] in Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "70206-8",
        "display": "Codeine [Moles/volume] in Urine by Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "19601-4",
        "display": "Morphine Free [Presence] in Urine by Screen method"
      },
      {
        "system": "http://loinc.org",
        "code": "19602-2",
        "display": "Morphine Free [Presence] in Urine by Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "19603-0",
        "display": "Morphine Free cutoff [Mass/volume] in Urine for Screen method"
      },
      {
        "system": "http://loinc.org",
        "code": "19604-8",
        "display": "Morphine Free cutoff [Mass/volume] in Urine for Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "20550-0",
        "display": "Morphine Free [Mass/volume] in Urine by Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "3828-1",
        "display": "Morphine Free [Presence] in Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "3829-9",
        "display": "Morphine Free [Mass/volume] in Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "13648-1",
        "display": "Morphine [Presence] in Urine by SAMHSA confirm method"
      },
      {
        "system": "http://loinc.org",
        "code": "16196-8",
        "display": "Morphine [Presence] in Urine by Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "16251-1",
        "display": "Morphine [Mass/volume] in Urine by Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "19597-4",
        "display": "Morphine [Presence] in Urine by Screen method"
      },
      {
        "system": "http://loinc.org",
        "code": "19599-0",
        "display": "Morphine cutoff [Mass/volume] in Urine for Screen method"
      },
      {
        "system": "http://loinc.org",
        "code": "19600-6",
        "display": "Morphine cutoff [Mass/volume] in Urine for Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "3830-7",
        "display": "Morphine [Presence] in Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "3831-5",
        "display": "Morphine [Mass/volume] in Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "3832-3",
        "display": "Morphine [Mass/time] in 24 hour Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "58392-2",
        "display": "Morphine/Creatinine [Mass Ratio] in Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "70210-0",
        "display": "Morphine [Moles/volume] in Urine by Confirmatory method"
      },
      {
        "system": "http://loinc.org",
        "code": "78768-9",
        "display": "Morphine [Mass/volume] in Urine -- adjusted for lean body mass+urine creatinine"
      },
      {
        "system": "http://loinc.org",
        "code": "78861-2",
        "display": "Morphine [Z-score] in Urine"
      },
      {
        "system": "http://loinc.org",
        "code": "111228-3",
        "display": "Codeine [Measurement] in Urine",
        "extension": [
          {
            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
            "extension": [
              {
                "url": "code",
                "valueCode": "status"
              },
              {
                "url": "value",
                "valueCode": "TRIAL"
              }
            ]
          }
        ]
      },
      {
        "system": "http://loinc.org",
        "code": "111393-5",
        "display": "Morphine [Measurement] in Urine",
        "extension": [
          {
            "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.contains.property",
            "extension": [
              {
                "url": "code",
                "valueCode": "status"
              },
              {
                "url": "value",
                "valueCode": "TRIAL"
              }
            ]
          }
        ]
      }
    ],
    "extension": [
      {
        "url": "http://hl7.org/fhir/5.0/StructureDefinition/extension-ValueSet.expansion.property",
        "extension": [
          {
            "url": "code",
            "valueCode": "status"
          },
          {
            "url": "uri",
            "valueUri": "http://hl7.org/fhir/concept-properties#status"
          }
        ]
      }
    ]
  }